### PR TITLE
Fix increment/samples race condition NPE

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Version 7.0.1
+  * fixed NPE race condition when incrementing or adding samples
+
 Version 7.0.0
   * added support for sending metrics using multiple lwes events rather than a
     single one

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.mondemand</groupId>
   <artifactId>mondemand-java</artifactId>
   <packaging>jar</packaging>
-  <version>7.0.0</version>
+  <version>7.0.1</version>
   <name>mondemand-java</name>
   <description>MonDemand java implementation</description>
   <url>http://mondemand.org</url>

--- a/src/main/java/org/mondemand/Client.java
+++ b/src/main/java/org/mondemand/Client.java
@@ -534,9 +534,6 @@ public class Client {
         contextStats.clear();
       }
     }
-    if(samples != null) {
-      samples.clear();
-    }
   }
 
   /**
@@ -601,12 +598,16 @@ public class Client {
       realKey = ClassUtils.getCallingClass(CALLER_DEPTH);
     }
 
+    // Note: increment could be lost due to a race condition but no
+    //       synchronization is required.
     StatsMessage realValue = (StatsMessage) this.stats.get(realKey);
     if(realValue == null) {
       // create the counter if doesn't exist
-      realValue = new StatsMessage(realKey, type);
-      this.stats.putIfAbsent(realKey, realValue);
-      realValue = this.stats.get(realKey);
+      StatsMessage newValue = new StatsMessage(realKey, type);
+      realValue = this.stats.putIfAbsent(realKey, newValue);
+      if(realValue == null) {
+        realValue = newValue;
+      }
     }
     // update the counter
     realValue.incrementBy(value);
@@ -620,12 +621,16 @@ public class Client {
    */
   public void increment(ContextList context, String keyType, long value)
   {
+    // Note: add could be lost due to a race condition but no
+    //       synchronization is required.
     AtomicLongMap<String> stats = contextStats.get(context);
     if (stats == null)
     {
-      stats = AtomicLongMap.create();
-      contextStats.putIfAbsent(context, stats);
-      stats = contextStats.get(context);
+      AtomicLongMap<String> newStats = AtomicLongMap.create();
+      stats = contextStats.putIfAbsent(context, newStats);
+      if(stats == null) {
+        stats = newStats;
+      }
     }
     stats.addAndGet(keyType, value);
   }
@@ -674,12 +679,18 @@ public class Client {
       realKey = ClassUtils.getCallingClass(CALLER_DEPTH);
     }
 
+    // Note: sample could be lost if we get the SamplesMessage but fail to
+    //       add the sample before the SamplesMessage is emitted.
+    //       This approach avoids synchronization though.
     SamplesMessage realValue = (SamplesMessage) this.samples.get(realKey);
     if(realValue == null) {
       // create the counter if doesn't exist
-      realValue = new SamplesMessage(realKey, trackingTypeValue, samplesMaxCount);
-      this.samples.putIfAbsent(realKey, realValue);
-      realValue = this.samples.get(realKey);
+      SamplesMessage newValue =
+          new SamplesMessage(realKey, trackingTypeValue, samplesMaxCount);
+      realValue = this.samples.putIfAbsent(realKey, newValue);
+      if(realValue == null) {
+        realValue = newValue;
+      }
     }
     // update the counter
     realValue.addSample(value);
@@ -1267,7 +1278,7 @@ public class Client {
 
       // snapshot samples map for dispatch
       SamplesMessage[] samplesMsgs = this.samples.values().toArray(new SamplesMessage[0]);
-      this.samples = new ConcurrentHashMap<String, SamplesMessage>();
+      this.samples = new ConcurrentHashMap<String, SamplesMessage>(this.samples.size());
 
       for (Transport t : transports.get(EventType.STATS)) {
         try {

--- a/src/main/java/org/mondemand/Client.java
+++ b/src/main/java/org/mondemand/Client.java
@@ -1073,22 +1073,20 @@ public class Client {
                                Map<String, String> context) {
     boolean ret = false;
     try {
-      /* FIXME: I'm sure there's a better way to do this but I am not the best
-       * java programmer.
-       */
-      ConcurrentHashMap<String,Context> tmp =
-        new ConcurrentHashMap<String,Context>();
-      for (Entry<String,String> entry : context.entrySet())
-        {
-          tmp.put(entry.getKey(),
-                  new Context(entry.getKey(), entry.getValue()));
+      List<Context> contextsList = new ArrayList<Context>(context.size() + 3);
+      contextsList.add(new Context(OWNER_KEY, owner));
+      contextsList.add(new Context(TRACE_KEY, traceId));
+      contextsList.add(new Context(MESSAGE_KEY, message));
+      for (Entry<String, String> entry : context.entrySet()) {
+        if (OWNER_KEY.equals(entry.getKey()) ||
+            TRACE_KEY.equals(entry.getKey()) ||
+            MESSAGE_KEY.equals(entry.getKey())) {
+          // skip anything set in the context with the arguments
+          continue;
         }
-      /* override anything set in the context with the arguments */
-      tmp.put(owner, new Context(OWNER_KEY, owner));
-      tmp.put(traceId, new Context(TRACE_KEY, traceId));
-      tmp.put(message, new Context(MESSAGE_KEY, message));
-
-      Context[] contexts = tmp.values().toArray(new Context[0]);
+        contextsList.add(new Context(entry.getKey(), entry.getValue()));
+      }
+      Context[] contexts = contextsList.toArray(new Context[0]);
 
       for (Transport t : transports.get(EventType.TRACE)) {
         try {


### PR DESCRIPTION
In the original code, the second get call on line 682 can return null if the samples were emitted between the putIfAbsent on line 681 and the second get call resulting in an NPE on line 685. Similar things can happen on increment and increment with a context.
This should fix the NPE while preserving the intent of the code without introducing additional synchonization