### PR TITLE
Updating to Java 1.8 and some minor performance improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+.classpath
+.project
+.settings
 target
 /target

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Version 8.0.0
+  * Updating to Java 1.8
+  * Performance improvements with StatsMessage and SamplesMessage
+
 Version 7.0.1
   * fixed NPE race condition when incrementing or adding samples
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.mondemand</groupId>
   <artifactId>mondemand-java</artifactId>
   <packaging>jar</packaging>
-  <version>7.0.1</version>
+  <version>8.0.0</version>
   <name>mondemand-java</name>
   <description>MonDemand java implementation</description>
   <url>http://mondemand.org</url>
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>11.0.2</version>
+      <version>21.0</version>
     </dependency>
   </dependencies>
 
@@ -84,10 +84,16 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>3.6.0</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
+          <compilerArgs>
+            <arg>-Werror</arg>
+            <arg>-Xlint</arg>
+          </compilerArgs>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/org/mondemand/Context.java
+++ b/src/main/java/org/mondemand/Context.java
@@ -29,6 +29,7 @@ public class Context implements Serializable {
   /**
    * @param key the key to set
    */
+  @Deprecated
   public void setKey(String key) {
     this.key = key;
   }
@@ -43,11 +44,9 @@ public class Context implements Serializable {
   /**
    * @param value the value to set
    */
+  @Deprecated
   public void setValue(String value) {
     this.value = value;
-  }
-
-  public Context() {
   }
 
   public Context(String k, String v) {

--- a/src/main/java/org/mondemand/StatsMessage.java
+++ b/src/main/java/org/mondemand/StatsMessage.java
@@ -13,6 +13,7 @@
 package org.mondemand;
 
 import java.io.Serializable;
+import java.util.concurrent.atomic.LongAdder;
 
 import org.mondemand.StatType;
 
@@ -21,7 +22,7 @@ public class StatsMessage implements Serializable {
 
   private String key = null;
   private StatType type = StatType.Unknown;
-  private long counter = 0;
+  private LongAdder counter = new LongAdder();
 
   /**
    * constructor
@@ -52,7 +53,7 @@ public class StatsMessage implements Serializable {
    * @return the counter
    */
   public long getCounter() {
-    return counter;
+    return counter.sum();
   }
 
   /**
@@ -60,18 +61,16 @@ public class StatsMessage implements Serializable {
    * @param value - value to increment by
    */
   public void incrementBy(int value) {
-    // synchronize on this object so it won't be updated while another
-    // thread is sending this instance's stats
-    synchronized(this) {
-      counter += value;
-    }
+    counter.add(value);
   }
 
   /**
    * @param counter the counter to set
    */
   public void setCounter(long counter) {
-    this.counter = counter;
+    // Not atomic but this should be ok
+    this.counter.reset();
+    this.counter.add(counter);
   }
 
   /**
@@ -89,6 +88,7 @@ public class StatsMessage implements Serializable {
     this.type = type;
   }
 
+  @Override
   public String toString() {
     return type + " : " + key + " : " + counter;
   }

--- a/src/test/java/org/mondemand/tests/SamplesMessagetTest.java
+++ b/src/test/java/org/mondemand/tests/SamplesMessagetTest.java
@@ -1,10 +1,18 @@
 package org.mondemand.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
 
 import org.junit.Test;
+import org.mondemand.SampleTrackType;
 import org.mondemand.SamplesMessage;
 import org.mondemand.StatType;
 
@@ -41,7 +49,6 @@ public class SamplesMessagetTest {
       assertEquals(0, msg.getCounter());
       assertEquals(0, msg.getUpdateCounts());
       assertEquals(samplesMaxCount, msg.getSamplesMaxCount());
-      assertEquals(0, msg.getSamples().size());
 
       // now add samples, different sizes for samples
       int sampleSize = rnd.nextInt(1000) + 500;
@@ -56,19 +63,163 @@ public class SamplesMessagetTest {
       assertEquals(StatType.Gauge, msg.getType());
       assertEquals(trackType, msg.getTrackingTypeValue());
       assertEquals(total, msg.getCounter());
-      assertEquals(Math.min(samplesMaxCount, sampleSize), msg.getSamples().size());
       assertEquals(sampleSize, msg.getUpdateCounts());
-
-      // reset the samples and check the values
-      msg.resetSamples();
-      assertEquals(key, msg.getKey());
-      assertEquals(StatType.Gauge, msg.getType());
-      assertEquals(trackType, msg.getTrackingTypeValue());
-      assertEquals(0, msg.getCounter());
-      assertEquals(0, msg.getUpdateCounts());
-      assertEquals(samplesMaxCount, msg.getSamplesMaxCount());
-      assertEquals(0, msg.getSamples().size());
     }
   }
 
+  @Test
+  public void testGetStats()
+  {
+    {
+      // Test all stats
+      final int allStats = Arrays.stream(SampleTrackType.values()).mapToInt(s -> s.value).sum();
+      SamplesMessage msg = new SamplesMessage("blah", allStats);
+      for (int i = 100; i > 0; --i) {
+        // Add samples backwards to test sorting
+        msg.addSample(i * 10);
+      }
+      final long sum = IntStream.range(1, 101).sum() * 10;
+
+      Map<SampleTrackType, Long> stats = msg.getStats();
+      for (Map.Entry<SampleTrackType, Long> stat : stats.entrySet()) {
+        switch (stat.getKey()) {
+          case MIN:
+            assertEquals(10, stat.getValue().longValue());
+            break;
+          case MAX:
+            assertEquals(1000, stat.getValue().longValue());
+            break;
+          case AVG:
+            assertEquals(sum / 100, stat.getValue().longValue());
+            break;
+          case MEDIAN:
+            assertEquals(500, stat.getValue().longValue());
+            break;
+          case PCTL_75:
+            assertEquals(750, stat.getValue().longValue());
+            break;
+          case PCTL_90:
+            assertEquals(900, stat.getValue().longValue());
+            break;
+          case PCTL_95:
+            assertEquals(950, stat.getValue().longValue());
+            break;
+          case PCTL_98:
+            assertEquals(980, stat.getValue().longValue());
+            break;
+          case PCTL_99:
+            assertEquals(990, stat.getValue().longValue());
+            break;
+          case SUM:
+            assertEquals(sum, stat.getValue().longValue());
+            break;
+          case COUNT:
+            assertEquals(100, stat.getValue().longValue());
+            break;
+        }
+      }
+    }
+    {
+      // Test No stats
+      SamplesMessage msg = new SamplesMessage("blah", 0, 100);
+      for (int i = 100; i > 0; --i) {
+        msg.addSample(i * 10);
+      }
+      Map<SampleTrackType, Long> stats = msg.getStats();
+      assertTrue(stats.isEmpty());
+    }
+    {
+      // Test partial stats
+      SamplesMessage msg = new SamplesMessage("blah", SampleTrackType.MEDIAN.value, 100);
+      for (int i = 100; i > 0; --i) {
+        msg.addSample(i * 10);
+      }
+      Map<SampleTrackType, Long> stats = msg.getStats();
+      assertEquals(1, stats.size());
+      assertEquals(500, stats.get(SampleTrackType.MEDIAN).longValue());
+    }
+  }
+
+  public class TestUpdater implements Runnable {
+    final SamplesMessage msg;
+    public int count = 0;
+
+    public TestUpdater(SamplesMessage msg) {
+      this.msg = msg;
+    }
+
+    @Override
+    public void run() {
+      while (!Thread.currentThread().isInterrupted()) {
+        if (msg.addSample(ThreadLocalRandom.current().nextInt(1000))) {
+          ++count;
+        }
+      }
+    }
+  }
+
+  public class TestEmitter implements Runnable {
+    final SamplesMessage msg;
+    public int count = 0;
+
+    public TestEmitter(SamplesMessage msg) {
+      this.msg = msg;
+    }
+
+    @Override
+    public void run() {
+      while (!Thread.currentThread().isInterrupted()) {
+        System.out.println(msg.getStats().get(SampleTrackType.COUNT));
+        ++count;
+        try {
+          Thread.sleep(500);
+        } catch (InterruptedException e) {
+          // interrupted
+          return;
+        }
+      }
+    }
+  }
+
+  /**
+   * This doesn't really test anything, its just to measure performance changes
+   * @throws InterruptedException
+   */
+  @Test
+  public void testThroughput() throws InterruptedException {
+    final int updaterCount = 100;
+
+    System.out.format("---%d updaters, 1 emitter 100 ms sleep---:\n", updaterCount);
+    SamplesMessage msg =
+        new SamplesMessage("blah", SampleTrackType.MEDIAN.value + SampleTrackType.AVG.value + SampleTrackType.COUNT.value,
+            SamplesMessage.MAX_SAMPLES_COUNT);
+    List<TestUpdater> updaters = new ArrayList<>(updaterCount);
+    for (int i = 0; i < updaterCount; ++i) {
+      updaters.add(new TestUpdater(msg));
+    }
+    TestEmitter emitter = new TestEmitter(msg);
+
+    List<Thread> threads = new ArrayList<>(updaterCount + 1);
+    for (TestUpdater updater : updaters) {
+      threads.add(new Thread(updater));
+    }
+    threads.add(new Thread(emitter));
+
+    long startTime = System.nanoTime();
+    for (Thread t : threads) {
+      t.start();
+    }
+    Thread.sleep(10500);
+    for (Thread t : threads) {
+      t.interrupt();
+    }
+    for (Thread t : threads) {
+      t.join(50);
+    }
+    long elapsedTime = System.nanoTime() - startTime;
+
+    System.out.format("Time: %d\n", elapsedTime);
+    System.out.format("Updates: %d\n", updaters.stream().mapToInt(u -> u.count).sum());
+    System.out.format("Emits %d\n\n", emitter.count);
+  }
 }


### PR DESCRIPTION
looking for feedback.
Some refactoring and cleaning up of conditions which never occur.
Main performance changes are StatsMessage uses a LongAdder instead of synchronization and
SamplesMessage uses AtomicInteger, AtomicIntegerArray and LongAdder instead of synchronization. It will be possible for stats to emit during mid update now, but I think the difference shouldn't really matter much and it can handle twice as many update calls.