### PR TITLE
Reject invalid keys for stats, samples, and contexts

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Version 8.0.0
+  * Reject invalid keys for stats, samples, and contexts
+
 Version 7.0.1
   * fixed NPE race condition when incrementing or adding samples
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.mondemand</groupId>
   <artifactId>mondemand-java</artifactId>
   <packaging>jar</packaging>
-  <version>7.0.1</version>
+  <version>8.0.0</version>
   <name>mondemand-java</name>
   <description>MonDemand java implementation</description>
   <url>http://mondemand.org</url>
@@ -50,6 +50,16 @@
       <type>jar</type>
       <version>1.2.16</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.4</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,16 +52,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.4</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <type>jar</type>

--- a/src/main/java/org/mondemand/Client.java
+++ b/src/main/java/org/mondemand/Client.java
@@ -74,8 +74,8 @@ public class Client {
   private Thread emitterThread = null;
   private Integer maxNumMetrics = null;
 
-  // key is the verified key, value specifies if a key is valid or not
-  static private ConcurrentHashMap<String, Boolean> verifiedKeys = new ConcurrentHashMap<String, Boolean>();
+  // key is the examined key, value specifies if the key is valid or not
+  static private ConcurrentHashMap<String, Boolean> examinedKeys = new ConcurrentHashMap<String, Boolean>();
 
   /********************************
    * CONSTRUCTORS AND DESTRUCTORS *
@@ -420,10 +420,10 @@ public class Client {
       return false;
     }
     // look up the map first to avoid calling matcher when possible
-    Boolean valid = verifiedKeys.get(key);
+    Boolean valid = examinedKeys.get(key);
     if(valid == null) {
       valid = keyPattern.matcher(key).matches();
-      verifiedKeys.putIfAbsent(key, valid);
+      examinedKeys.putIfAbsent(key, valid);
     }
     return valid.booleanValue();
   }

--- a/src/main/java/org/mondemand/Client.java
+++ b/src/main/java/org/mondemand/Client.java
@@ -345,7 +345,7 @@ public class Client {
     if(value == null || value.isEmpty()) {
       throw new MondemandException("value is empty or null");
     }
-    if(!keyIsValid(key)) {
+    if(!isKeyValid(key)) {
       throw new MondemandException("key is invalid: " + key);
     }
 
@@ -413,15 +413,12 @@ public class Client {
    * @return true if the key consists of valid characters, false if otherwise
    *         or key is empty.
    */
-  public static boolean keyIsValid(String key) {
+  public static boolean isKeyValid(String key) {
     if(key == null || key.isEmpty()) {
       return false;
     }
     Matcher matcher = keyPattern.matcher(key);
-    if(!matcher.matches()) {
-      return false;
-    }
-    return true;
+    return matcher.matches();
   }
 
   /**
@@ -632,7 +629,7 @@ public class Client {
       realKey = ClassUtils.getCallingClass(CALLER_DEPTH);
     }
 
-    if(!keyIsValid(realKey)) {
+    if(!isKeyValid(realKey)) {
       throw new MondemandException("key is invalid: " + realKey);
     }
 
@@ -665,7 +662,7 @@ public class Client {
    */
   public void increment(ContextList context, String keyType, long value) throws MondemandException
   {
-    if(!keyIsValid(keyType)) {
+    if(!isKeyValid(keyType)) {
       throw new MondemandException("key is invalid: " + keyType);
     }
 
@@ -723,7 +720,7 @@ public class Client {
       realKey = ClassUtils.getCallingClass(CALLER_DEPTH);
     }
 
-    if(!keyIsValid(realKey)) {
+    if(!isKeyValid(realKey)) {
       throw new MondemandException("key is invalid: " + realKey);
     }
 
@@ -815,7 +812,7 @@ public class Client {
       realKey = ClassUtils.getCallingClass(CALLER_DEPTH);
     }
 
-    if(!keyIsValid(realKey)) {
+    if(!isKeyValid(realKey)) {
       throw new MondemandException("key is invalid: " + realKey);
     }
 

--- a/src/main/java/org/mondemand/Context.java
+++ b/src/main/java/org/mondemand/Context.java
@@ -14,6 +14,8 @@ package org.mondemand;
 
 import java.io.Serializable;
 
+import static org.mondemand.Client.keyIsValid;
+
 public class Context implements Serializable {
   private static final long serialVersionUID = -6801370115780644951L;
   private String key = null;
@@ -27,32 +29,24 @@ public class Context implements Serializable {
   }
 
   /**
-   * @param key the key to set
-   */
-  public void setKey(String key) {
-    this.key = key;
-  }
-
-  /**
    * @return the value
    */
   public String getValue() {
     return value;
   }
 
-  /**
-   * @param value the value to set
-   */
-  public void setValue(String value) {
-    this.value = value;
-  }
-
-  public Context() {
-  }
-
-  public Context(String k, String v) {
+  public Context(String k, String v) throws MondemandException {
     key = k;
     value = v;
+    if(key == null) {
+      throw new MondemandException("key is null");
+    }
+    if(value == null || value.isEmpty()) {
+      throw new MondemandException("value is empty or null");
+    }
+    if(!keyIsValid(key)) {
+      throw new MondemandException("key is invalid: " + key);
+    }
   }
 
   @Override
@@ -66,23 +60,30 @@ public class Context implements Serializable {
 
   @Override
   public boolean equals(Object obj) {
-    if (this == obj)
+    if (this == obj) {
       return true;
-    if (obj == null)
+    }
+    if (obj == null) {
       return false;
-    if (getClass() != obj.getClass())
+    }
+    if (getClass() != obj.getClass()) {
       return false;
+    }
     Context other = (Context) obj;
     if (key == null) {
-      if (other.key != null)
+      if (other.key != null) {
         return false;
-    } else if (!key.equals(other.key))
+      }
+    } else if (!key.equals(other.key)) {
       return false;
+    }
     if (value == null) {
-      if (other.value != null)
+      if (other.value != null) {
         return false;
-    } else if (!value.equals(other.value))
+      }
+    } else if (!value.equals(other.value)) {
       return false;
+    }
     return true;
   }
 

--- a/src/main/java/org/mondemand/Context.java
+++ b/src/main/java/org/mondemand/Context.java
@@ -14,7 +14,7 @@ package org.mondemand;
 
 import java.io.Serializable;
 
-import static org.mondemand.Client.keyIsValid;
+import static org.mondemand.Client.isKeyValid;
 
 public class Context implements Serializable {
   private static final long serialVersionUID = -6801370115780644951L;
@@ -44,7 +44,7 @@ public class Context implements Serializable {
     if(value == null || value.isEmpty()) {
       throw new MondemandException("value is empty or null");
     }
-    if(!keyIsValid(key)) {
+    if(!isKeyValid(key)) {
       throw new MondemandException("key is invalid: " + key);
     }
   }

--- a/src/main/java/org/mondemand/MondemandException.java
+++ b/src/main/java/org/mondemand/MondemandException.java
@@ -1,0 +1,10 @@
+package org.mondemand;
+
+public class MondemandException extends Exception {
+
+  private static final long serialVersionUID = 867135884407982292L;
+
+  public MondemandException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/mondemand/transport/LWESTransport.java
+++ b/src/main/java/org/mondemand/transport/LWESTransport.java
@@ -36,6 +36,7 @@ import org.mondemand.TransportException;
 public class LWESTransport
   implements Transport
 {
+
   /********************
    * Constants        *
    ********************/
@@ -106,13 +107,16 @@ public class LWESTransport
     }
   }
 
+  @Override
   public void sendLogs (String programId,
                         LogMessage[] messages,
                         Context[] contexts)
     throws TransportException
   {
     if (messages == null || messages.length == 0
-        || contexts == null || emitterGroup == null) return;
+        || contexts == null || emitterGroup == null) {
+      return;
+    }
 
     try {
       // create the event and set parameters
@@ -163,6 +167,7 @@ public class LWESTransport
    * @param contexts - contexts
    * @throws TransportException
    */
+  @Override
   public void send(String programId, StatsMessage[] stats,
       SamplesMessage[] samples, Context[] contexts, Integer maxNumMetrics)
     throws TransportException
@@ -320,11 +325,13 @@ public class LWESTransport
     {
       statsMsg.setString("prog_id", programId);
       statsMsg.setUInt16("num", numMetrics);
-      statsMsg.setUInt16("ctxt_num", contexts.length);
-      for (int i = 0; i < contexts.length; ++i) {
-        statsMsg.setString("ctxt_k" + i, contexts[i].getKey());
-        statsMsg.setString("ctxt_v" + i, contexts[i].getValue());
+      int contextCount = 0;
+      for (Context context : contexts) {
+        statsMsg.setString("ctxt_k" + contextCount, context.getKey());
+        statsMsg.setString("ctxt_v" + contextCount, context.getValue());
+        ++contextCount;
       }
+      statsMsg.setUInt16("ctxt_num", contextCount);
 
       emitterGroup.emitToGroup(statsMsg);
 
@@ -370,12 +377,14 @@ public class LWESTransport
   private static final String PROG_ID_KEY  = "mondemand.prog_id";
   private static final String SRC_HOST_KEY = "mondemand.src_host";
 
+  @Override
   public void sendTrace (String programId,
                          Context[] contexts)
     throws TransportException
   {
-    if (contexts == null || emitterGroup == null)
+    if (contexts == null || emitterGroup == null) {
       return;
+    }
 
     try {
       Event traceMsg = emitterGroup.createEvent(TRACE_EVENT, false);
@@ -400,6 +409,7 @@ public class LWESTransport
   private static final String PERF_START_PREFIX = "start";
   private static final String PERF_END_PREFIX = "end";
 
+  @Override
   public void sendPerformanceTrace(String id, String callerLabel,
                                    String[] label, long[] start,
                                    long[] end, Context[] contexts)
@@ -447,6 +457,7 @@ public class LWESTransport
     }
   }
 
+  @Override
   public void shutdown()
     throws TransportException
   {

--- a/src/test/java/org/mondemand/tests/ClientTest.java
+++ b/src/test/java/org/mondemand/tests/ClientTest.java
@@ -680,8 +680,8 @@ public class ClientTest {
   @Test
   public void testIsValid() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
     Client client = createClientNoTransports();
-    Field verifiedKeys = client.getClass().getDeclaredField("verifiedKeys");
-    verifiedKeys.setAccessible(true);
+    Field examinedKeys = client.getClass().getDeclaredField("examinedKeys");
+    examinedKeys.setAccessible(true);
 
     String[] validKeys = {"valid", "valid_with_underscore", "valid.with.dot", "valid-with-dash",
         "valid_with_numbers_090", "valid_with-all.chars090"};
@@ -698,7 +698,7 @@ public class ClientTest {
     for(String validKey : validKeys) {
       assertTrue(Client.isKeyValid(validKey));
       @SuppressWarnings("unchecked")
-      ConcurrentHashMap<String, Boolean> b = (ConcurrentHashMap<String, Boolean>)verifiedKeys.get(validKey);
+      ConcurrentHashMap<String, Boolean> b = (ConcurrentHashMap<String, Boolean>)examinedKeys.get(validKey);
       assertTrue( b.get(validKey) );
     }
     for(String invalidKey : invalidKeys) {
@@ -706,7 +706,7 @@ public class ClientTest {
       // null and empty string are not put in to the map
       if(invalidKey != null && !invalidKey.equals("")) {
         @SuppressWarnings("unchecked")
-        ConcurrentHashMap<String, Boolean> b = (ConcurrentHashMap<String, Boolean>)verifiedKeys.get(invalidKey);
+        ConcurrentHashMap<String, Boolean> b = (ConcurrentHashMap<String, Boolean>)examinedKeys.get(invalidKey);
         assertFalse(b.get(invalidKey));
       }
     }

--- a/src/test/java/org/mondemand/tests/ClientTest.java
+++ b/src/test/java/org/mondemand/tests/ClientTest.java
@@ -576,7 +576,6 @@ public class ClientTest {
       assertEquals(g.eventValuesSize(), 0);
 
       // add samples
-      // add stats
       try {
         client.addSample(invalidKey, 100, 1);
         // fail if we are not throwing exception
@@ -596,7 +595,7 @@ public class ClientTest {
    * @throws Exception
    */
   @Test
-  public void testStatsWithValidKeys() throws Exception {
+  public void testStatsSamplesWithValidKeys() throws Exception {
     String[] validKeys = {"valid", "valid_with_underscore", "valid.with.dot", "valid-with-dash", "valid-with.numbers_090"};
 
     // stats
@@ -679,12 +678,12 @@ public class ClientTest {
     String[] validKeys = {"valid", "valid_with_underscore", "valid.with.dot", "valid-with-dash",
         "valid_with_numbers_090", "valid_with-all.chars090"};
     for(String validKey : validKeys) {
-      assertTrue(Client.keyIsValid(validKey));
+      assertTrue(Client.isKeyValid(validKey));
     }
     String[] invalidKeys = {null, "", "with space", "with_invalid_chars_%", "with_invalid_chars_$",
         "with_invalid_chars_+", "with_invalid_chars_:", "with_invalid_chars_="};
     for(String invalidKey : invalidKeys) {
-      assertFalse(Client.keyIsValid(invalidKey));
+      assertFalse(Client.isKeyValid(invalidKey));
     }
   }
 


### PR DESCRIPTION
This is a backward incompatible change as some of the methods will now throw exception which should be caught by the calling method. 
Nick and I talked about whether we should throw exception or log an error message, and we decide to do the former. 
Note that a lot of the changes in the code were made because my editor changed to code to make it comply with our PMD. I could change those back if people think they are annoying.